### PR TITLE
MSVC compatibility

### DIFF
--- a/indexer/src/CMakeLists.txt
+++ b/indexer/src/CMakeLists.txt
@@ -43,6 +43,16 @@ if (BUILD_FAST_INDEXER OR BUILD_FAST_INDEXER_STATIC)
                 set(CMAKE_CUDA_ARCHITECTURES "75;80")
         endif()
         find_package(CUDAToolkit REQUIRED)
+
+         if (MSVC)
+                # indexer_gpu.cu pulls in CUB (<cub/block/block_radix_sort.cuh>). CUB — like all of
+                # CCCL (Thrust/CUB/libcu++) — hard-#errors unless MSVC uses its standard-conforming
+                # preprocessor, because its macro machinery relies on conforming __VA_ARGS__ handling
+                # that MSVC's traditional preprocessor gets wrong. Forward /Zc:preprocessor to the
+                # host compiler for the CUDA sources.
+                set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/Zc:preprocessor")
+        endif()
+        
         message("CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}")
         set(fast_indexer_PUB_HEADER_LIST
                 ffbidx/indexer.h

--- a/indexer/src/indexer_gpu.cu
+++ b/indexer/src/indexer_gpu.cu
@@ -67,7 +67,7 @@ namespace {
     // NOTE: not allowed as member of constant
     // (dl * 2^N) mod 2pi
     template<typename float_type>
-    __constant__ static constexpr float_type dl2pNmod2pi[32] = {
+    __constant__ static float_type dl2pNmod2pi[32] = {
         0.76393202250021030359082633,   // N = 0
         1.5278640450004206071816527,
         3.0557280900008412143633053,


### PR DESCRIPTION
After trying to build fast feedback indexer with MSVC 2026 + CUDA 13.3, I've encountered two problems:
- constexpr had to be dropped
- preprocessor flag had to be added to handle NVIDIA library